### PR TITLE
Add tutorial notebook for igor2 AFM analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # igor2_tutorial
-Tutorial notebook for using igor2 to analyze .ibw files from Asylum Research AFM.
+
+Tutorial notebook for using igor2 to analyze `.ibw` files from Asylum Research AFM.
+
+## Getting started
+
+1. Open `notebooks/igor2_afm_tutorial.ipynb` in Jupyter (Anaconda, VS Code, or `jupyter notebook`).
+2. Follow the guided steps to install dependencies, load your `.ibw` file, extract metadata, and plot AFM channels.
+3. Replace the placeholder file path in the notebook with your own data location.
+
+The notebook is written for users who are new to Python, with detailed comments for each step.

--- a/notebooks/igor2_afm_tutorial.ipynb
+++ b/notebooks/igor2_afm_tutorial.ipynb
@@ -1,0 +1,267 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Analyzing Asylum Research AFM `.ibw` files with `igor2`",
+        "",
+        "This tutorial walks through a simple, end-to-end workflow for opening, inspecting, and plotting Atomic Force Microscope (AFM) images stored in **Igor Binary Wave** (`.ibw`) files using the [`igor2`](https://pypi.org/project/igor2/) Python package. It is written for people who are comfortable with AFM data but new to Python."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## What you will need",
+        "",
+        "- A working Python 3 environment. The commands here assume you are running inside a Jupyter notebook or a Python-friendly environment such as VS Code.",
+        "- An `.ibw` file exported from Asylum Research AFM software.",
+        "- Basic familiarity with your file system (where the data file is stored) is helpful, but no prior Python knowledge is required."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 1. Install required packages",
+        "",
+        "The two packages we rely on are:",
+        "",
+        "- **igor2** for reading `.ibw` files.",
+        "- **matplotlib** for plotting images.",
+        "",
+        "Run the cell below to install them. The `-q` flag keeps the output concise."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Install the igor2 reader and plotting library.",
+        "# Remove \"-q\" if you want to see full installation logs.",
+        "!pip install -q igor2 matplotlib"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 2. Import libraries",
+        "",
+        "Each import pulls common, beginner-friendly tools:",
+        "",
+        "- `os` is used to build file paths that work on Windows, macOS, and Linux.",
+        "- `igor` comes from the `igor2` package and reads `.ibw` files.",
+        "- `matplotlib.pyplot` (aliased as `plt`) plots images.",
+        "- `pprint` is handy for printing nested dictionaries in a readable way."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os",
+        "from pprint import pprint",
+        "",
+        "import igor",
+        "from matplotlib import pyplot as plt"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 3. Confirm the installation",
+        "",
+        "`help(igor)` prints the documentation that ships with the package. If the package was installed correctly, you should see an overview of the available modules and functions."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "help(igor)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 4. Locate your `.ibw` file",
+        "",
+        "Update the two variables below to point to your data:",
+        "",
+        "- `data_dir` \u2013 the folder containing your `.ibw` files.",
+        "- `filename` \u2013 the name of the file you want to open.",
+        "",
+        "If your file is in the same directory as this notebook, you can leave `data_dir` empty (`\"\"`). Otherwise, paste the full path to the folder. The code builds a combined `path` that works cross-platform."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# TODO: Replace these with your own paths.",
+        "data_dir = \"\"  # Example: r\"C:\\Users\\you\\Documents\\afm\" or \"/home/you/data\"",
+        "filename = \"test.ibw\"  # Example: \"my_afm_scan.ibw\"",
+        "",
+        "path = os.path.join(data_dir, filename)",
+        "print(f\"Loading: {path}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 5. Load the `.ibw` file",
+        "",
+        "`igor.binarywave.load()` returns a dictionary containing both the raw data array and metadata. If the path is wrong, you will see a clear error message, so double-check the folder and file name if you run into trouble."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "file = igor.binarywave.load(path)",
+        "print(\"Top-level keys:\", file.keys())",
+        "print(\"Wave keys:\", file['wave'].keys())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 6. Decode channel labels",
+        "",
+        "AFM images typically store multiple channels (e.g., height, amplitude, phase) inside the same cube of data. Labels are stored as raw bytes, so we decode them to human-readable text and collect them in a simple Python list."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "labels = []",
+        "for label in file['wave']['labels'][2][1:]:  # Skip the first placeholder entry.",
+        "    labels.append(label.decode())",
+        "",
+        "print(\"Available channels:\")",
+        "for i, label in enumerate(labels):",
+        "    print(f\"  {i}: {label}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 7. Parse the measurement note",
+        "",
+        "The `note` field contains instrument settings and experimental notes as a single byte string. We split it into a dictionary for easier inspection. Certain degree and micro symbols are normalized so they render correctly in UTF-8."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "note = {}",
+        "for s in file['wave']['note']        .replace(b'\u00b0', b'\u00c2\u00b0')        .replace(b'\u00b5', b'\u00c2\u00b5')        .decode()        .split('\r'):",
+        "    s = s.strip()",
+        "    if not s or ':' not in s:",
+        "        continue",
+        "    key, value = s.split(':', 1)",
+        "    note[key.strip()] = value.strip()",
+        "",
+        "print(\"Parsed note entries:\")",
+        "pprint(note)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 8. Extract the data array",
+        "",
+        "`file['wave']['wData']` is a NumPy array with the shape `(y_pixels, x_pixels, channels)`. Confirm the shape so you know how many channels you can visualize."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "data = file['wave']['wData']",
+        "print(\"Data shape (rows, columns, channels):\", data.shape)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 9. Plot an AFM channel",
+        "",
+        "Pick the channel you want to visualize\u2014`HeightTrace` is a common choice. The snippet below locates the channel index by name, then plots it using a grayscale colormap. Feel free to experiment with other channel names from the `labels` list."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "channel_name = 'HeightTrace'  # Change this to any label printed above.",
+        "",
+        "try:",
+        "    channel_index = labels.index(channel_name)",
+        "except ValueError:",
+        "    raise ValueError(f\"Channel '{channel_name}' not found. Available: {labels}\")",
+        "",
+        "plt.figure(figsize=(6, 6))",
+        "plt.imshow(data[:, :, channel_index], cmap='gray')",
+        "plt.title(f\"AFM image: {channel_name}\")",
+        "plt.colorbar(label='Arbitrary units')",
+        "plt.axis('off')",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 10. Next steps",
+        "",
+        "- Try additional channels (e.g., `PhaseTrace`, `AmplitudeTrace`) by changing `channel_name`.",
+        "- Use `plt.subplots` to compare multiple channels side-by-side.",
+        "- Save figures with `plt.savefig(\"output.png\", dpi=300)` for publication-ready images.",
+        "- Explore other metadata stored under `file['wave']` to document your acquisition settings."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a step-by-step igor2 tutorial notebook for loading and plotting Asylum Research AFM `.ibw` files
- document how to open and use the notebook in the README for new Python users

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69367f8a64e08320ad5ff552d790f43c)